### PR TITLE
refactor: streamline state lookup and UI

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -682,9 +682,3 @@ h1 {
 .reset-all-btn:hover {
   background: #5a6268;
 }
-
-.test-modal-btn {
-  background: #28a745;
-  color: white;
-  margin-left: 10px;
-} 

--- a/src/components/TaxFilingTool.js
+++ b/src/components/TaxFilingTool.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { stateFilingData } from '../data/stateFilingData';
 import USMap from './USMap';
 import StatesModal from './StatesModal';
@@ -12,11 +12,14 @@ const TaxFilingTool = () => {
   const [modalStates, setModalStates] = useState([]);
 
   // State name to abbreviation mapping
-  const stateNameToAbbr = {};
-  Object.keys(stateFilingData).forEach(abbr => {
-    stateNameToAbbr[stateFilingData[abbr].name.toLowerCase()] = abbr;
-    stateNameToAbbr[abbr.toLowerCase()] = abbr;
-  });
+  const stateNameToAbbr = useMemo(() => {
+    const mapping = {};
+    Object.keys(stateFilingData).forEach(abbr => {
+      mapping[stateFilingData[abbr].name.toLowerCase()] = abbr;
+      mapping[abbr.toLowerCase()] = abbr;
+    });
+    return mapping;
+  }, []);
 
   const addState = () => {
     const stateInputTrimmed = stateInput.trim();
@@ -276,12 +279,6 @@ const TaxFilingTool = () => {
             onClick={resetAll}
           >
             Reset All
-          </button>
-          <button 
-            className="action-button test-modal-btn" 
-            onClick={() => showStatesModal('required')}
-          >
-            Test Modal
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- avoid rebuilding the state name to abbreviation map on every render using `useMemo`
- remove leftover "Test Modal" button and its unused styles for a cleaner interface

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68accbd5a4b08331ad394ab799f97b40