### PR TITLE
feat: lighten theme and enhance map interactivity

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -11,11 +11,14 @@
 .container {
   max-width: 1200px;
   margin: 0 auto;
-  background: #ffffff;
+  background: rgba(255, 255, 255, 0.4);
   border-radius: 12px;
   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.05);
   padding: 40px;
   transition: box-shadow 0.3s ease;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.3);
 }
 
 .container:hover {
@@ -31,9 +34,11 @@ h1 {
 .form-section {
   margin-bottom: 30px;
   padding: 25px;
-  background: var(--color-light);
+  background: rgba(255, 255, 255, 0.35);
   border-radius: 8px;
-  border: 1px solid var(--color-medium);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
 }
 
 .form-section h3 {
@@ -97,10 +102,12 @@ h1 {
   gap: 5px;
   cursor: pointer;
   padding: 7px 10px;
-  background: var(--color-light);
-  border: 2px solid var(--color-medium);
+  background: rgba(255, 255, 255, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.3);
   border-radius: 6px;
   transition: background 0.3s, transform 0.2s, box-shadow 0.2s, border-color 0.3s;
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
   min-width: 0;
   height: 40px;
   box-sizing: border-box;
@@ -124,7 +131,7 @@ h1 {
 
 .filing-type-option:hover {
   border-color: var(--color-dark);
-  background: #fff;
+  background: rgba(255, 255, 255, 0.6);
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
@@ -189,11 +196,13 @@ h1 {
 .selected-states-section {
   margin-top: 20px;
   padding: 15px;
-  background: #ffffff;
+  background: rgba(255, 255, 255, 0.35);
   border-radius: 8px;
-  border: 1px solid var(--color-medium);
+  border: 1px solid rgba(255, 255, 255, 0.3);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
   transition: box-shadow 0.3s, transform 0.2s;
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
 }
 
 .selected-states-section:hover {
@@ -210,10 +219,12 @@ h1 {
 .total-count {
   text-align: center;
   padding: 10px;
-  background: var(--color-light);
+  background: rgba(255, 255, 255, 0.35);
   border-radius: 6px;
-  border: 1px solid var(--color-medium);
+  border: 1px solid rgba(255, 255, 255, 0.3);
   margin-bottom: 15px;
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
 }
 
 .total-count h5 {
@@ -230,10 +241,12 @@ h1 {
 }
 
 .bucket {
-  background: white;
+  background: rgba(255, 255, 255, 0.35);
   border-radius: 6px;
-  border: 1px solid var(--color-medium);
+  border: 1px solid rgba(255, 255, 255, 0.3);
   padding: 15px;
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
 }
 
 .bucket-header {
@@ -335,9 +348,11 @@ h1 {
 
 .filing-summary {
   padding: 15px;
-  background: white;
+  background: rgba(255, 255, 255, 0.35);
   border-radius: 6px;
-  border: 1px solid #dee2e6;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
 }
 
 .filing-summary h5 {

--- a/src/components/USMap.js
+++ b/src/components/USMap.js
@@ -179,6 +179,12 @@ const USMap = ({ selectedStates, filingType, onStateClick }) => {
       const stateData = stateFilingData[stateId];
 
       stateElement.addEventListener('mouseenter', (e) => {
+        // Hover styling for interactivity
+        stateElement.style.transform = 'scale(1.03)';
+        stateElement.style.stroke = '#333';
+        stateElement.style.strokeWidth = '2';
+        stateElement.style.filter = 'drop-shadow(0 0 6px rgba(0,0,0,0.2))';
+
         // Remove any existing tooltip before creating a new one
         if (tooltipRef.current) {
           document.body.removeChild(tooltipRef.current);
@@ -332,6 +338,10 @@ const USMap = ({ selectedStates, filingType, onStateClick }) => {
           document.body.removeChild(tooltipRef.current);
           tooltipRef.current = null;
         }
+        stateElement.style.transform = '';
+        stateElement.style.stroke = '';
+        stateElement.style.strokeWidth = '';
+        stateElement.style.filter = '';
       });
     }
   }, []);
@@ -362,15 +372,15 @@ const USMap = ({ selectedStates, filingType, onStateClick }) => {
     legendOverlay.className = 'legend-overlay';
     legendOverlay.innerHTML = `
       <div class="legend-item">
-        <div class="legend-color" style="background: #28a745;"></div>
+        <div class="legend-color" style="background: #8dd39e;"></div>
         <span>Filing Required</span>
       </div>
       <div class="legend-item">
-        <div class="legend-color" style="background: #6c757d;"></div>
+        <div class="legend-color" style="background: #b0bec5;"></div>
         <span>No Filing Required</span>
       </div>
       <div class="legend-item">
-        <div class="legend-color" style="background: #ffc107;"></div>
+        <div class="legend-color" style="background: #ffe58a;"></div>
         <span>Conditional Filing</span>
       </div>
       <div class="legend-item">
@@ -395,15 +405,15 @@ const USMap = ({ selectedStates, filingType, onStateClick }) => {
         
         if (stateElement) {
           let textColor = '#000000'; // Default to black
-          
-          if (stateElement.classList.contains('filing-required') || stateElement.style.fill === '#28a745') {
+
+          if (stateElement.classList.contains('filing-required') || stateElement.style.fill === '#8dd39e') {
             textColor = '#ffffff'; // White for green
-          } else if (stateElement.classList.contains('no-filing') || stateElement.style.fill === '#6c757d') {
-            textColor = '#ffffff'; // White for grey
-          } else if (stateElement.classList.contains('conditional-filing') || stateElement.style.fill === '#ffc107') {
+          } else if (stateElement.classList.contains('no-filing') || stateElement.style.fill === '#b0bec5') {
+            textColor = '#000000'; // Dark text for light grey
+          } else if (stateElement.classList.contains('conditional-filing') || stateElement.style.fill === '#ffe58a') {
             textColor = '#000000'; // Black for yellow
           }
-          
+
           textElement.style.setProperty('fill', textColor, 'important');
           textElement.setAttribute('fill', textColor);
         }
@@ -418,7 +428,7 @@ const USMap = ({ selectedStates, filingType, onStateClick }) => {
     const stateElements = svgContainerRef.current.querySelectorAll('.state');
     stateElements.forEach(stateElement => {
       stateElement.classList.remove('filing-required', 'no-filing', 'conditional-filing');
-      stateElement.style.setProperty('fill', '#f0f0f0', 'important');
+      stateElement.style.setProperty('fill', '#f9fafb', 'important');
     });
     
     // Color selected states based on filing requirements
@@ -430,13 +440,13 @@ const USMap = ({ selectedStates, filingType, onStateClick }) => {
         
         if (filingStatus === 'required') {
           stateElement.classList.add('filing-required');
-          stateElement.style.fill = '#28a745';
+          stateElement.style.fill = '#8dd39e';
         } else if (filingStatus === 'conditional') {
           stateElement.classList.add('conditional-filing');
-          stateElement.style.fill = '#ffc107';
+          stateElement.style.fill = '#ffe58a';
         } else if (filingStatus === 'not-required') {
           stateElement.classList.add('no-filing');
-          stateElement.style.fill = '#6c757d';
+          stateElement.style.fill = '#b0bec5';
         }
       }
     });
@@ -474,11 +484,13 @@ const USMap = ({ selectedStates, filingType, onStateClick }) => {
             state.removeAttribute('fill');
             
             // Set default styling
-            state.style.setProperty('fill', '#f0f0f0', 'important');
+            state.style.setProperty('fill', '#f9fafb', 'important');
             state.style.cursor = 'pointer';
-            state.style.transition = 'fill 0.3s, stroke-width 0.3s';
+            state.style.transition = 'fill 0.3s, stroke-width 0.3s, transform 0.2s';
             state.style.position = 'relative';
-            
+            state.style.transformBox = 'fill-box';
+            state.style.transformOrigin = 'center';
+          
             // Add state class
             state.classList.add('state', 'clickable');
             

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,13 @@
 :root {
-  --primary: #4f46e5;
-  --primary-dark: #4338ca;
-  --accent: #06b6d4;
-  --gray-100: #f1f5f9;
-  --gray-300: #cbd5e1;
-  --gray-600: #475569;
-  --color-light: #bcb2a1;
-  --color-medium: #887d71;
-  --color-dark: #473827;
+  --primary: #a5b4fc;
+  --primary-dark: #818cf8;
+  --accent: #67e8f9;
+  --gray-100: #f8fafc;
+  --gray-300: #e2e8f0;
+  --gray-600: #94a3b8;
+  --color-light: #f5f0e9;
+  --color-medium: #e5ddd3;
+  --color-dark: #b8a28a;
 }
 
 body {


### PR DESCRIPTION
## Summary
- switch to lighter, pastel color palette
- introduce glass-like styling for main UI containers
- add hover scaling and drop shadow for map states with matching lighter legend colors

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68adb156b7d4833190d4e104f08533d1