### PR TITLE
Streamline pricing tool layout and add test modal

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -706,42 +706,14 @@ h1 {
   background: var(--primary);
 }
 
-.pricing-section {
-  margin-top: 20px;
-  padding: 15px;
-  background: #ffffff;
-  border: 1px solid var(--color-medium);
-  border-radius: 8px;
-}
-
-.calculate-price-btn {
-  padding: 10px 20px;
+.test-modal-btn {
   background: var(--color-dark);
-  color: #fff;
-  border: none;
-  border-radius: 5px;
-  cursor: pointer;
-  font-size: 16px;
-  transition: background 0.3s, transform 0.2s, box-shadow 0.2s;
-  margin-top: 10px;
 }
 
-.calculate-price-btn:hover {
+.test-modal-btn:hover {
   background: var(--color-medium);
-  transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0,0,0,0.15);
 }
 
-.price-details {
-  margin-top: 10px;
-  line-height: 1.6;
-}
-
-.state-pricing-note {
-  margin-top: 8px;
-  font-size: 14px;
-  color: var(--color-medium);
-}
 .pricing-section {
   margin-top: 20px;
   padding: 15px;

--- a/src/components/TaxFilingTool.js
+++ b/src/components/TaxFilingTool.js
@@ -99,6 +99,12 @@ const TaxFilingTool = () => {
     setShowModal(false);
   };
 
+  const openTestModal = () => {
+    setModalTitle('Test Modal');
+    setModalStates(selectedStates);
+    setShowModal(true);
+  };
+
   const handleKeyPress = (e) => {
     if (e.key === 'Enter') {
       addState();
@@ -227,25 +233,6 @@ const TaxFilingTool = () => {
           </div>
         </div>
         
-          <div className="pricing-section">
-            <h4>Federal Return Pricing Calculator</h4>
-            <button className="calculate-price-btn" onClick={calculatePrice}>
-              Calculate Return Fee
-            </button>
-            {filingType === '1120' && (
-              <p className="state-pricing-note">First state return included.</p>
-            )}
-            {priceDetails && (
-              <div className="price-details">
-                <p>Federal Return Fee: ${priceDetails.basePrice}</p>
-                <p>
-                  State Returns ({priceDetails.stateCount}): ${priceDetails.statePrice}
-                </p>
-                <p><strong>Total Fee: ${priceDetails.total}</strong></p>
-              </div>
-            )}
-          </div>
-
           <div className="action-buttons">
             <button
               className="action-button select-all-btn"
@@ -253,11 +240,17 @@ const TaxFilingTool = () => {
             >
               Select All
           </button>
-          <button 
-            className="action-button reset-all-btn" 
+          <button
+            className="action-button reset-all-btn"
             onClick={resetAll}
           >
             Reset All
+          </button>
+          <button
+            className="action-button test-modal-btn"
+            onClick={openTestModal}
+          >
+            Test Modal
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Remove duplicate pricing calculator and place single instance after state summaries
- Add Test Modal action and styling for easy modal preview
- Clean up pricing section styles and consolidate duplicates

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68adb9b171748331b4643f88ee5c875b