### PR TITLE
chore: remove test modal

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -707,14 +707,6 @@ h1 {
   background: var(--primary);
 }
 
-.test-modal-btn {
-  background: var(--color-dark);
-}
-
-.test-modal-btn:hover {
-  background: var(--color-medium);
-}
-
 .pricing-section {
   margin-top: 20px;
   padding: 15px;

--- a/src/components/TaxFilingTool.js
+++ b/src/components/TaxFilingTool.js
@@ -66,12 +66,6 @@ const TaxFilingTool = () => {
     setShowModal(false);
   };
 
-  const openTestModal = () => {
-    setModalTitle('Test Modal');
-    setModalStates(selectedStates);
-    setShowModal(true);
-  };
-
   // Calculate counts for each bucket
   const getBucketCounts = () => {
     let requiredCount = 0;
@@ -177,23 +171,17 @@ const TaxFilingTool = () => {
         </div>
         
           <div className="action-buttons">
-            <button
-              className="action-button select-all-btn"
-              onClick={selectAll}
-            >
-              Select All
+          <button
+            className="action-button select-all-btn"
+            onClick={selectAll}
+          >
+            Select All
           </button>
           <button
             className="action-button reset-all-btn"
             onClick={resetAll}
           >
             Reset All
-          </button>
-          <button
-            className="action-button test-modal-btn"
-            onClick={openTestModal}
-          >
-            Test Modal
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove development-only test modal handler and button
- clean up test modal styles

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build` *(fails: Namespace tags are not supported by default)*

------
https://chatgpt.com/codex/tasks/task_e_68af03025da88331a81f7f5401e12f10