### PR TITLE
Inline conditional filing guidance

### DIFF
--- a/src/components/USMap.js
+++ b/src/components/USMap.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useCallback, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { stateFilingData } from '../data/stateFilingData';
-import { getConditionalText } from '../data/stateFilingData';
 import { ReactComponent as USSVG } from '../assets/us.svg';
 
 const TooltipContent = ({ stateId, stateData }) => {
@@ -23,12 +22,12 @@ const TooltipContent = ({ stateId, stateData }) => {
     }
   }
 
-  const hasConditional = Object.values(stateData.forms).some(status => status === 'conditional');
-  const conditionalWarning = hasConditional ? (
-    <div className="tooltip-note" style={{ margin: 0, fontSize: '11px' }}>
-      <strong>Conditional: {getConditionalText(stateId)}</strong>
-    </div>
-  ) : null;
+    const hasConditional = Object.values(stateData.forms).some(status => status === 'conditional');
+    const conditionalWarning = hasConditional && stateData.conditionalText ? (
+      <div className="tooltip-note" style={{ margin: 0, fontSize: '11px' }}>
+        <strong>Conditional: {stateData.conditionalText}</strong>
+      </div>
+    ) : null;
 
   let warningBlock = null;
   if (warnings.length && conditionalWarning) {

--- a/src/data/stateFilingData.js
+++ b/src/data/stateFilingData.js
@@ -17,8 +17,8 @@ export const stateFilingData = {
   'IA': { name: 'Iowa', forms: { '1120S': 'required', '1065': 'required', '1120': 'required', '1040': 'required' }},
   'KS': { name: 'Kansas', forms: { '1120S': 'not-required', '1065': 'not-required', '1120': 'required', '1040': 'required' }},
   'KY': { name: 'Kentucky', forms: { '1120S': 'required', '1065': 'required', '1120': 'required', '1040': 'required' }, cityReturns: { type: 'specific', cities: ['Lexington', 'Louisville'] }},
-  'LA': { name: 'Louisiana', forms: { '1120S': 'conditional', '1065': 'conditional', '1120': 'required', '1040': 'conditional' }},
-  'ME': { name: 'Maine', forms: { '1120S': 'conditional', '1065': 'conditional', '1120': 'required', '1040': 'conditional' }},
+  'LA': { name: 'Louisiana', forms: { '1120S': 'conditional', '1065': 'conditional', '1120': 'required', '1040': 'conditional' }, conditionalText: 'If partners are non-residents' },
+  'ME': { name: 'Maine', forms: { '1120S': 'conditional', '1065': 'conditional', '1120': 'required', '1040': 'conditional' }, conditionalText: 'If partners are non-residents' },
   'MD': { name: 'Maryland', forms: { '1120S': 'required', '1065': 'required', '1120': 'required', '1040': 'required' }, cityReturns: { type: 'all', cities: [] }},
   'MA': { name: 'Massachusetts', forms: { '1120S': 'required', '1065': 'required', '1120': 'required', '1040': 'required' }},
   'MI': { name: 'Michigan', forms: { '1120S': 'not-required', '1065': 'not-required', '1120': 'required', '1040': 'required' }, cityReturns: { type: 'all', cities: [] }},
@@ -28,13 +28,13 @@ export const stateFilingData = {
   'MT': { name: 'Montana', forms: { '1120S': 'required', '1065': 'required', '1120': 'required', '1040': 'required' }},
   'NE': { name: 'Nebraska', forms: { '1120S': 'required', '1065': 'required', '1120': 'required', '1040': 'required' }},
   'NV': { name: 'Nevada', forms: { '1120S': 'not-required', '1065': 'not-required', '1120': 'required', '1040': 'not-required' }},
-  'NH': { name: 'New Hampshire', forms: { '1120S': 'conditional', '1065': 'conditional', '1120': 'required', '1040': 'conditional' }},
+  'NH': { name: 'New Hampshire', forms: { '1120S': 'conditional', '1065': 'conditional', '1120': 'required', '1040': 'conditional' }, conditionalText: 'Over $50k income' },
   'NJ': { name: 'New Jersey', forms: { '1120S': 'required', '1065': 'required', '1120': 'required', '1040': 'required' }},
   'NM': { name: 'New Mexico', forms: { '1120S': 'required', '1065': 'required', '1120': 'required', '1040': 'required' }},
   'NY': { name: 'New York', forms: { '1120S': 'required', '1065': 'required', '1120': 'required', '1040': 'required' }, cityReturns: { type: 'specific', cities: ['New York City', 'Yonkers'] }},
   'NC': { name: 'North Carolina', forms: { '1120S': 'required', '1065': 'required', '1120': 'required', '1040': 'required' }},
   'ND': { name: 'North Dakota', forms: { '1120S': 'required', '1065': 'required', '1120': 'required', '1040': 'required' }},
-  'OH': { name: 'Ohio', forms: { '1120S': 'conditional', '1065': 'conditional', '1120': 'required', '1040': 'conditional' }, cityReturns: { type: 'all', cities: [] }},
+  'OH': { name: 'Ohio', forms: { '1120S': 'conditional', '1065': 'conditional', '1120': 'required', '1040': 'conditional' }, cityReturns: { type: 'all', cities: [] }, conditionalText: 'If partners are non-residents' },
   'OK': { name: 'Oklahoma', forms: { '1120S': 'required', '1065': 'required', '1120': 'required', '1040': 'required' }},
   'OR': { name: 'Oregon', forms: { '1120S': 'required', '1065': 'required', '1120': 'required', '1040': 'required' }, cityReturns: { type: 'specific', cities: ['Portland'] }},
   'PA': { name: 'Pennsylvania', forms: { '1120S': 'required', '1065': 'required', '1120': 'required', '1040': 'required' }, cityReturns: { type: 'specific', cities: ['Philadelphia'] }},
@@ -43,7 +43,7 @@ export const stateFilingData = {
   'SD': { name: 'South Dakota', forms: { '1120S': 'not-required', '1065': 'not-required', '1120': 'required', '1040': 'not-required' }},
   'TN': { name: 'Tennessee', forms: { '1120S': 'required', '1065': 'required', '1120': 'required', '1040': 'not-required' }},
   'TX': { name: 'Texas', forms: { '1120S': 'required', '1065': 'required', '1120': 'required', '1040': 'not-required' }},
-  'UT': { name: 'Utah', forms: { '1120S': 'conditional', '1065': 'conditional', '1120': 'required', '1040': 'conditional' }},
+  'UT': { name: 'Utah', forms: { '1120S': 'conditional', '1065': 'conditional', '1120': 'required', '1040': 'conditional' }, conditionalText: 'If partners are corporate or non-residents' },
   'VT': { name: 'Vermont', forms: { '1120S': 'required', '1065': 'required', '1120': 'required', '1040': 'required' }},
   'VA': { name: 'Virginia', forms: { '1120S': 'required', '1065': 'required', '1120': 'required', '1040': 'required' }},
   'WA': { name: 'Washington', forms: { '1120S': 'not-required', '1065': 'not-required', '1120': 'required', '1040': 'not-required' }},
@@ -52,17 +52,5 @@ export const stateFilingData = {
   'WY': { name: 'Wyoming', forms: { '1120S': 'not-required', '1065': 'not-required', '1120': 'required', '1040': 'not-required' }}
 };
 
-export const getConditionalText = (stateId) => {
-  switch (stateId) {
-    case 'LA':
-    case 'ME':
-    case 'OH':
-      return 'If partners are non-residents';
-    case 'NH':
-      return 'Over $50k income';
-    case 'UT':
-      return 'If partners are corporate or non-residents';
-    default:
-      return 'See detailed notes for specific criteria';
-  }
-}; 
+// Deprecated: getConditionalText has been removed in favor of the
+// `conditionalText` field within each state's data object.


### PR DESCRIPTION
## Summary
- add `conditionalText` property to conditional state entries
- drop `getConditionalText` helper and read `stateData.conditionalText` in map tooltip

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68af094436dc8331957a6c82efc3069e