### PR TITLE
Initialize state labels during map setup

### DIFF
--- a/src/components/USMap.js
+++ b/src/components/USMap.js
@@ -380,13 +380,12 @@ const USMap = ({ selectedStates, filingType, onStateClick }) => {
       state.style.transformBox = 'fill-box';
       state.style.transformOrigin = 'center';
       state.classList.add('state', 'clickable');
-      addStateLabel(state);
       state.addEventListener('mouseenter', handleMouseEnter);
       state.addEventListener('mousemove', handleMouseMove);
       state.addEventListener('mouseleave', handleMouseLeave);
       state.addEventListener('click', handleClick);
     },
-    [addStateLabel, handleMouseEnter, handleMouseMove, handleMouseLeave, handleClick]
+    [handleMouseEnter, handleMouseMove, handleMouseLeave, handleClick]
   );
 
   useEffect(() => {
@@ -396,12 +395,15 @@ const USMap = ({ selectedStates, filingType, onStateClick }) => {
     }
     if (svgRef.current && !initializedRef.current) {
       const states = svgRef.current.querySelectorAll('path[id]');
-      states.forEach((state) => setupStateElement(state));
+      states.forEach((state) => {
+        setupStateElement(state);
+        addStateLabel(state);
+      });
       addLegendOverlay();
       updateMap();
       initializedRef.current = true;
     }
-  }, [setupStateElement, addLegendOverlay, updateMap]);
+  }, [setupStateElement, addStateLabel, addLegendOverlay, updateMap]);
 
   useEffect(() => {
     if (typeof document === 'undefined') return;


### PR DESCRIPTION
## Summary
- Apply default map styling per state via `setupStateElement`
- Add state abbreviation labels for each state path during initialization
- Refresh legend overlay and map colors after applying default state styles

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68af3e8fb52c833197dfcca20b98e241